### PR TITLE
Add buttons for GIMP & Inkscape

### DIFF
--- a/nwg_icon_picker/__about__.py
+++ b/nwg_icon_picker/__about__.py
@@ -4,6 +4,6 @@ except ImportError:
     import importlib_metadata as metadata
 
 try:
-    __version__ = metadata.version("nwg-icon_picker")
+    __version__ = metadata.version("nwg_icon_picker")
 except Exception:
     __version__ = "unknown"

--- a/nwg_icon_picker/__about__.py
+++ b/nwg_icon_picker/__about__.py
@@ -4,6 +4,6 @@ except ImportError:
     import importlib_metadata as metadata
 
 try:
-    __version__ = metadata.version("nwg_icon_picker")
+    __version__ = metadata.version("nwg-icon-picker")
 except Exception:
     __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='nwg-icon-picker',
-    version='0.0.1',
+    version='0.1.0',
     description='GTK icon picker with textual search',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Added GIMP and Inkscape buttons next to the icon path, to allow opening icons in these programs. The buttons won’t show up if corresponding programs are not installed.